### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Of course, no one template will serve all projects since your needs may be diffe
 
 ## Built With
 
-Whilst I was the main developer of this project, this project couldn't of even started without the help of these open source projects, special thanks to:
+Whilst I was the main developer of this project, this project couldn't have even started without the help of these open source projects, special thanks to:
 
 - [JavaScript](https://www.javascript.com/)
 - [VueJS](https://vuejs.org/)


### PR DESCRIPTION
Fix misspelling of "could of" to "could have" in README

See more at:
https://writingexplained.org/could-of-or-could-have#:~:text=Could%20of%20is%20a%20common%20misspelling%20of%20the%20verb%20phrase%20could%20have